### PR TITLE
[respeaker_ros] Avoid AudioInfo import for backward compatibility

### DIFF
--- a/respeaker_ros/scripts/respeaker_node.py
+++ b/respeaker_ros/scripts/respeaker_node.py
@@ -16,7 +16,13 @@ import struct
 import sys
 import time
 from audio_common_msgs.msg import AudioData
-from audio_common_msgs.msg import AudioInfo
+enable_audio_info = True
+try:
+    from audio_common_msgs.msg import AudioInfo
+except Exception as e:
+    rospy.logwarn('audio_common_msgs/AudioInfo message is not exists.'
+                  ' AudioInfo message will not be published.')
+    enable_audio_info = False
 from geometry_msgs.msg import PoseStamped
 from std_msgs.msg import Bool, Int32, ColorRGBA
 from dynamic_reconfigure.server import Server
@@ -332,8 +338,9 @@ class RespeakerNode(object):
         self.pub_doa_raw = rospy.Publisher("sound_direction", Int32, queue_size=1, latch=True)
         self.pub_doa = rospy.Publisher("sound_localization", PoseStamped, queue_size=1, latch=True)
         self.pub_audio = rospy.Publisher("audio", AudioData, queue_size=10)
-        self.pub_audio_info = rospy.Publisher("audio_info", AudioInfo,
-                                              queue_size=1, latch=True)
+        if enable_audio_info is True:
+            self.pub_audio_info = rospy.Publisher("audio_info", AudioInfo,
+                                                  queue_size=1, latch=True)
         self.pub_audio_raw_info = rospy.Publisher("audio_info_raw", AudioInfo,
                                                   queue_size=1, latch=True)
         self.pub_speech_audio = rospy.Publisher("speech_audio", AudioData, queue_size=10)
@@ -357,13 +364,14 @@ class RespeakerNode(object):
         self.sub_led = rospy.Subscriber("status_led", ColorRGBA, self.on_status_led)
 
         # processed audio for ASR
-        info_msg = AudioInfo(
-            channels=1,
-            sample_rate=self.respeaker_audio.rate,
-            sample_format='S16LE',
-            bitrate=self.respeaker_audio.rate * self.respeaker_audio.bitdepth,
-            coding_format='WAVE')
-        self.pub_audio_info.publish(info_msg)
+        if enable_audio_info is True:
+            info_msg = AudioInfo(
+                channels=1,
+                sample_rate=self.respeaker_audio.rate,
+                sample_format='S16LE',
+                bitrate=self.respeaker_audio.rate * self.respeaker_audio.bitdepth,
+                coding_format='WAVE')
+            self.pub_audio_info.publish(info_msg)
 
         if self.n_channel > 1:
             # The respeaker has 4 microphones.
@@ -387,14 +395,15 @@ class RespeakerNode(object):
             self.pub_audio_merged_playback = rospy.Publisher(
                 "audio_merged_playback", AudioData,
                 queue_size=10)
-            info_raw_msg = AudioInfo(
-                channels=self.n_channel - 2,
-                sample_rate=self.respeaker_audio.rate,
-                sample_format='S16LE',
-                bitrate=(self.respeaker_audio.rate *
-                         self.respeaker_audio.bitdepth),
-                coding_format='WAVE')
-            self.pub_audio_raw_info.publish(info_raw_msg)
+            if enable_audio_info is True:
+                info_raw_msg = AudioInfo(
+                    channels=self.n_channel - 2,
+                    sample_rate=self.respeaker_audio.rate,
+                    sample_format='S16LE',
+                    bitrate=(self.respeaker_audio.rate *
+                             self.respeaker_audio.bitdepth),
+                    coding_format='WAVE')
+                self.pub_audio_raw_info.publish(info_raw_msg)
 
             self.speech_audio_raw_buffer = b""
             self.speech_raw_prefetch_buffer = b""

--- a/respeaker_ros/scripts/respeaker_node.py
+++ b/respeaker_ros/scripts/respeaker_node.py
@@ -410,7 +410,7 @@ class RespeakerNode(object):
             self.pub_speech_audio_raw = rospy.Publisher(
                 "speech_audio_raw", AudioData, queue_size=10)
             self.speech_raw_prefetch_bytes = int(
-                self.n_channel - 2
+                (self.n_channel - 2)
                 * self.speech_prefetch
                 * self.respeaker_audio.rate
                 * self.respeaker_audio.bitdepth / 8.0)

--- a/respeaker_ros/scripts/speech_to_text.py
+++ b/respeaker_ros/scripts/speech_to_text.py
@@ -4,6 +4,8 @@
 
 from __future__ import division
 
+import sys
+
 import actionlib
 import rospy
 try:
@@ -14,7 +16,13 @@ except ImportError as e:
 import numpy as np
 from actionlib_msgs.msg import GoalStatus, GoalStatusArray
 from audio_common_msgs.msg import AudioData
-from audio_common_msgs.msg import AudioInfo
+enable_audio_info = True
+try:
+    from audio_common_msgs.msg import AudioInfo
+except Exception as e:
+    rospy.logwarn('audio_common_msgs/AudioInfo message is not exists.'
+                 ' AudioInfo message will not be published.')
+    enable_audio_info = False
 from sound_play.msg import SoundRequest, SoundRequestAction, SoundRequestGoal
 from speech_recognition_msgs.msg import SpeechRecognitionCandidates
 
@@ -24,6 +32,11 @@ class SpeechToText(object):
         # format of input audio data
         audio_info_topic_name = rospy.get_param('~audio_info', '')
         if len(audio_info_topic_name) > 0:
+            if enable_audio_info is False:
+                rospy.logerr(
+                    'audio_common_msgs/AudioInfo message is not exists.'
+                    ' Giving ~audio_info is not valid in your environment.')
+                sys.exit(1)
             rospy.loginfo('Extract audio info params from {}'.format(
                 audio_info_topic_name))
             audio_info_msg = rospy.wait_for_message(


### PR DESCRIPTION
I am very sorry, but for a long time, I forgot to merge the following pull request.
https://github.com/708yamaguchi/jsk_3rdparty/pull/4

After merging this PR, both fetch15 branch and pr1040 branch has the feature introduced in the following PR.
https://github.com/jsk-ros-pkg/jsk_3rdparty/pull/350