### PR TITLE
[rostwitter] Suppress tweet log

### DIFF
--- a/rostwitter/scripts/tweet.py
+++ b/rostwitter/scripts/tweet.py
@@ -28,7 +28,7 @@ class Tweet(object):
 
     def tweet_cb(self, msg):
         message = msg.data
-        rospy.loginfo(rospy.get_name() + " sending %s", message)
+        rospy.logdebug(rospy.get_name() + " sending %s", message)
 
         ret = self.api.post_update(message)
         if 'errors' in ret:


### PR DESCRIPTION
This PR suppresses tweet log.
If Base64 encoding texts are displayed in logs, logs are too dirty to see.