### PR TITLE
[rostwitter] Add status_code to check error

### DIFF
--- a/rostwitter/python/rostwitter/twitter.py
+++ b/rostwitter/python/rostwitter/twitter.py
@@ -74,9 +74,14 @@ class Twitter(object):
                 data['media_ids'] = media_ids
             if in_reply_to_status_id is not None:
                 data['in_reply_to_status_id'] = in_reply_to_status_id
-            json = self._request_url(url, 'POST', data=data)
-            data = simplejson.loads(json.content)
-            in_reply_to_status_id = data['id']
+            r = self._request_url(url, 'POST', data=data)
+            data = simplejson.loads(r.content)
+            if r.status_code == 200:
+                rospy.loginfo('post update with reply success')
+                in_reply_to_status_id = data['id']
+            else:
+                rospy.logwarn('post update with reply failed. status_code: {}'
+                              .format(r.status_code))
         return data
 
     def _upload_media(self, media_list):
@@ -89,7 +94,8 @@ class Twitter(object):
                 rospy.loginfo('upload media success')
                 media_ids.append(str(r.json()['media_id']))
             else:
-                rospy.logwarn('upload media failed')
+                rospy.logwarn('upload media failed. status_code: {}'
+                              .format(r.status_code))
         media_ids = ','.join(media_ids)
         return media_ids
 
@@ -111,8 +117,13 @@ class Twitter(object):
         url = 'https://api.twitter.com/1.1/statuses/update_with_media.json'
         data = {'status': status}
         data['media'] = open(str(media), 'rb').read()
-        json = self._request_url(url, 'POST', data=data)
-        data = simplejson.loads(json.content)
+        r = self._request_url(url, 'POST', data=data)
+        data = simplejson.loads(r.content)
+        if r.status_code == 200:
+            rospy.loginfo('post media success')
+        else:
+            rospy.logwarn('post media failed. status_code: {}'
+                          .format(r.status_code))
         if len(texts) > 1:
             data = self._post_update_with_reply(
                 texts[1:],

--- a/rostwitter/scripts/tweet.py
+++ b/rostwitter/scripts/tweet.py
@@ -33,9 +33,8 @@ class Tweet(object):
                       ''.join([message] if len(message) < 128 else message[0:128]+'......'))
 
         ret = self.api.post_update(message)
-        if 'errors' in ret:
-            rospy.logerr('Failed to post: {}'.format(ret))
-        rospy.loginfo(rospy.get_name() + " receiving %s", ret)
+        if ret is not None:
+            rospy.loginfo(rospy.get_name() + " receiving %s", ret)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In current, sometimes error occuered when fetch1075 and fetch15 tweet.
To check the error, I added loginfo to monitor status_code.
cc: @nakane11
```
[ERROR] [1663815357.593281] [/tweet_image_server:rosout]: Exception in your execute callback: 'id'
Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/actionlib/simple_action_server.py", line 289, in executeLoop
    self.execute_callback(goal)
  File "/home/fetch/ros/melodic/src/jsk-ros-pkg/jsk_3rdparty/rostwitter/scripts/tweet_image_server.py", line 120, in _execute_cb
    ret = self.api.post_update(goal.text)
  File "/home/fetch/ros/melodic/src/jsk-ros-pkg/jsk_3rdparty/rostwitter/python/rostwitter/twitter.py", line 104, in post_update
    in_reply_to_status_id=in_reply_to_status_id)
  File "/home/fetch/ros/melodic/src/jsk-ros-pkg/jsk_3rdparty/rostwitter/python/rostwitter/twitter.py", line 79, in _post_update_with_reply
    in_reply_to_status_id = data['id']
KeyError: 'id'
```
